### PR TITLE
Open files of file:/// scheme with in-app viewer (closes #60)

### DIFF
--- a/app/src/main/res/values/licenses.xml
+++ b/app/src/main/res/values/licenses.xml
@@ -1,25 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="licenses" translatable="false">
-        <a href='https://github.com/google/gson'>Gson</a>
-        (<a href='file:///android_asset/licenses/Gson'>license</a>)\n
+        <![CDATA[
+        <a href="https://github.com/google/gson">Gson</a>
+        (<a href="file:///android_asset/licenses/Gson">license</a>)<br/>
 
-        <a href='https://www.flickr.com/photos/kc2daniel/9694177482/'>JEEP TRAIL IN LAKE CITY</a>
-        (<a href='file:///android_asset/licenses/JeepTrail'>license</a>)\n
+        <a href="https://www.flickr.com/photos/kc2daniel/9694177482/">JEEP TRAIL IN LAKE CITY</a>
+        (<a href="file:///android_asset/licenses/JeepTrail">license</a>)<br/>
 
-        <a href='https://github.com/PhilJay/MPAndroidChart'>MPAndroidChart</a>
-        (<a href='file:///android_asset/licenses/MPAndroidChart'>license</a>)\n
+        <a href="https://github.com/PhilJay/MPAndroidChart">MPAndroidChart</a>
+        (<a href="file:///android_asset/licenses/MPAndroidChart">license</a>)<br/>
 
-        <a href='https://openweathermap.org/'>OpenWeatherMap</a>
-        (<a href='file:///android_asset/licenses/OpenWeatherMap'>license</a>)\n
+        <a href="https://openweathermap.org/">OpenWeatherMap</a>
+        (<a href="file:///android_asset/licenses/OpenWeatherMap">license</a>)<br/>
 
-        <a href='https://github.com/google/roboto/'>Roboto</a>
-        (<a href='file:///android_asset/licenses/Roboto'>license</a>)\n
+        <a href="https://github.com/google/roboto/">Roboto</a>
+        (<a href="file:///android_asset/licenses/Roboto">license</a>)<br/>
 
-        <a href='https://erikflowers.github.io/weather-icons/'>Weather Icons</a>
-        (<a href='file:///android_asset/licenses/WeatherIcons'>license</a>)\n
+        <a href="https://erikflowers.github.io/weather-icons/">Weather Icons</a>
+        (<a href="file:///android_asset/licenses/WeatherIcons">license</a>)<br/>
 
-        <a href='https://merlinthered.deviantart.com/art/plain-weather-icons-157162192'>Plain Weather Icons</a>
-        (<a href='file:///android_asset/licenses/PlainWeatherIconsByMerlinTheRed'>license</a>)
+        <a href="https://merlinthered.deviantart.com/art/plain-weather-icons-157162192">Plain Weather Icons</a>
+        (<a href="file:///android_asset/licenses/PlainWeatherIconsByMerlinTheRed">license</a>)
+        ]]>
     </string>
 </resources>


### PR DESCRIPTION
On newer androids (24+) usage `file:///` scheme is forbidden and leads to app crash (FileUriExposedException).

In this app `file:///` scheme is used to pass local license files to external browser. And that causes app crash when pressing `(license)` for me and - I suppose - for author of #60.

This PR makes app open local license files with built-in webview, that fixes crash at least for me.

@comradekingu, please can you check if issue is fixed? I've built signed APK for you: [apk](https://github.com/thuryn/your-local-weather/files/4143229/YourLocationWeather-release.apk.zip), but you have to uninstall previous version cuz this build is signed with different key.

