### PR TITLE
Fix the blocked celsius symbol on the main page

### DIFF
--- a/app/src/main/res/layout/main_content.xml
+++ b/app/src/main/res/layout/main_content.xml
@@ -98,7 +98,7 @@
                             android:gravity="center"
                             android:textAlignment="center"
                             android:textColor="@color/textColorPrimary"
-                            android:textSize="80sp"
+                            android:textSize="80dp"
                             tools:text="199"/>
                     </LinearLayout>
 


### PR DESCRIPTION
Dear developer:

Hello! I am the creator of issue #179, and I have fixed the blocked celsius symbol on the main page. I would genuinely appreciate it if you could kindly revise my code and leave me some advice. Thank you so much for your precious time!

Here is the screenshot after my changes:

<img src="https://user-images.githubusercontent.com/25502419/131814832-6c2e429a-12b7-4b1d-978f-f3e7871547bc.png" alt="copy" width="250"/>

Thanks again! Blessings on your day! :)