### PR TITLE
Updated README.md: "OpenWeatherMap.org" -> "Open-Meteo"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Location is updated by a distance counted by accelerometer. When distance is lon
 
 To get the location, cell network (BTS) and WIFIs available on the place are used. These information are used to get location coordinates by Mozilla location service. Application try to use GPS when location is not available from cell network and WIFIs. Location coordinates are used to get address by Nominatim service. The address is used in the application or widget.
 
-Application uses OpenWeatherMap.org service to get current weather .
+Application uses Open-Meteo service to get current and forecast weather.
 
 Additional features include:
 * Multilingual


### PR DESCRIPTION
I updated the read-me by replacing "OpenWeatherMap.org" with "Open-Meteo", because that is what the app uses since version 6.

The current descriptions of the app on Aptoide (https://your-local-weather.en.aptoide.com/app) and on the Google Play Store (https://play.google.com/store/apps/details?id=org.thosp.yourlocalweather) have already been updated, but the current description on f-droid (https://f-droid.org/packages/org.thosp.yourlocalweather/) is outdated and should also be updated exactly like this commit. Should I open a GitHub-issue for this?